### PR TITLE
Import random in compute_filtering.py

### DIFF
--- a/pipeline/compute_filtering.py
+++ b/pipeline/compute_filtering.py
@@ -1,4 +1,5 @@
 import json
+import random
 
 from pipeline.code_filter_config import text_filter_config, code_filter_config
 


### PR DESCRIPTION
I encountered many such errors in the `err_msg` field of the process result.
```
Traceback (most recent call last):
  File "/opc_data_filtering/pipeline/compute_filtering.py", line 39, in do_filter
    if func(quality_signal_json[filter_name]):
  File "<string>", line 1, in <lambda>
NameError: name 'random' is not defined
```
This PR adds `import random` to fix the missing `random` in `func(quality_signal_json[filter_name])`
